### PR TITLE
map routing / sign up update

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,15 +8,22 @@ body {
 }
 
 .map-container {
-  position: absolute;
+  position: relative;
   top: 0;
   right: 0;
   left: 0;
   bottom: 0;
+  height: 100%;
+  width: 100%;
 }
 
 .nav-container {
   margin: auto;
+}
+
+img#marker {
+  width: 40px;
+  height: 40px;
 }
 
 a {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,13 +29,13 @@ const App = () => {
                 component={login}
                 // authenticated={authenticated}
               />
-              <Route exact path="/signup" component={signup} />
+              <Route path="/signup" component={signup} />
             </Switch>
           </div>
         </Router>
       </div>
     </MuiThemeProvider>
   );
-}
+};
 
 export default App;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,12 +5,15 @@ const Navbar = () => {
   return (
     <AppBar position="fixed">
       <Toolbar className="nav-container">
-        <Button color="inherit" component={Link} to="/login" >Login</Button>
-        <Button color="inherit" component={Link} to="/" >Home</Button>
-        <Button color="inherit" component={Link} to="signup" >Signup</Button>
+        <Button color="inherit" component={Link} to="/login">
+          Login
+        </Button>
+        <Button color="inherit" component={Link} to="/">
+          Home
+        </Button>
       </Toolbar>
     </AppBar>
   );
 };
 
-export default Navbar
+export default Navbar;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { AppBar, Toolbar, Button } from "@material-ui/core";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from "./LanguageSwitcher";
 
 const Navbar = () => {
@@ -9,12 +9,8 @@ const Navbar = () => {
   return (
     <AppBar position="fixed">
       <Toolbar className="nav-container">
-        <Button color="inherit" component={Link} to="/login">
-          {t("login")}
-        </Button>
-        <Button color="inherit" component={Link} to="/">
-          {t("home")}
-        </Button>
+        <Button color="inherit" component={Link} to="/login" >{t("login")}</Button>
+        <Button color="inherit" component={Link} to="/" >{t("home")}</Button>
       </Toolbar>
       <LanguageSwitcher />
     </AppBar>

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -1,49 +1,83 @@
-import React, { useRef, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import mapboxgl from "mapbox-gl";
+import ReactMapGL, { Marker, Popup } from "react-map-gl";
 import getChains from "../util/firebase/chain";
+import { useHistory } from "react-router-dom";
+import { Button } from "@material-ui/core";
 
 mapboxgl.accessToken = `${process.env.REACT_APP_MAPBOX_KEY}`;
 
 const Map = () => {
-  //map config
-  const mapContainer = useRef();
+  const history = useHistory();
 
-  useEffect(async () => {
-    let chainData = await getChains();
+  const [viewport, setViewport] = useState({
+    latitude: 52.1326,
+    longitude: 5.2913,
+    zoom: 8,
+    width: "100vw",
+    height: "100vh",
+  });
 
-    const map = new mapboxgl.Map({
-      container: mapContainer.current,
-      style: "mapbox://styles/mapbox/streets-v11",
-      center: [5.2913, 52.1326],
-      zoom: 8,
-    });
+  const [chaindata, setChaindata] = useState([]);
+  const [selectedChain, setSelectedChain] = useState(null);
+  const [showPopup, setShowPopup] = useState(false);
 
-    chainData.forEach((chain) => {
-      let chainLatitude = chain.latLon.latitude;
-      let chainLongitude = chain.latLon.longitude;
-      let chainName = chain.name;
-
-      var popup = new mapboxgl.Popup({
-        offset: 25,
-        className: "chain-popup",
-      }).setHTML(
-        `<h1>${chainName}</h1><p>description of the chain here</p><button>sign up here</button>`
-      );
-
-      var marker = new mapboxgl.Marker({
-        color: "red",
-        draggable: true,
-      })
-        .setLngLat([chainLongitude, chainLatitude])
-        .setPopup(popup)
-        .addTo(map);
+  useEffect(() => {
+    getChains().then((response) => {
+      setChaindata(response);
     });
   }, []);
 
   return (
-    <div>
-      <div className="map-container" ref={mapContainer} />
-    </div>
+    <ReactMapGL
+      mapboxApiAccessToken={mapboxgl.accessToken}
+      mapStyle="mapbox://styles/mapbox/streets-v11"
+      {...viewport}
+      onViewportChange={(newView) => setViewport(newView)}
+    >
+      {chaindata.map((chain) => (
+        <Marker
+          key={chain.name}
+          latitude={chain.latLon.latitude}
+          longitude={chain.latLon.longitude}
+          onClick={(e) => {
+            e.preventDefault();
+            setSelectedChain(chain);
+            setShowPopup(true);
+          }}
+        >
+          {" "}
+          <img
+            id="marker"
+            src="https://cdn0.iconfinder.com/data/icons/small-n-flat/24/678111-map-marker-512.png"
+            alt="Map Marker"
+          />
+        </Marker>
+      ))}
+
+      {selectedChain && showPopup ? (
+        <Popup
+          latitude={selectedChain.latLon.latitude}
+          longitude={selectedChain.latLon.longitude}
+          closeOnClick={false}
+          onClose={() => setShowPopup(false)}
+          dynamicPosition={false}
+        >
+          <div className={"chain-popup"}>
+            <h2>{selectedChain.name}</h2>
+            <p>description of the chain here</p>
+            <Button
+              onClick={(e) => {
+                e.preventDefault();
+                history.replace(`./signup/?chain=${selectedChain.name}`);
+              }}
+            >
+              Sign up{" "}
+            </Button>
+          </div>
+        </Popup>
+      ) : null}
+    </ReactMapGL>
   );
 };
 

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -18,13 +18,13 @@ const Map = () => {
     height: "100vh",
   });
 
-  const [chaindata, setChaindata] = useState([]);
+  const [chainData, setChainData] = useState([]);
   const [selectedChain, setSelectedChain] = useState(null);
   const [showPopup, setShowPopup] = useState(false);
 
   useEffect(() => {
     getChains().then((response) => {
-      setChaindata(response);
+      setChainData(response);
     });
   }, []);
 
@@ -35,7 +35,7 @@ const Map = () => {
       {...viewport}
       onViewportChange={(newView) => setViewport(newView)}
     >
-      {chaindata.map((chain) => (
+      {chainData.map((chain) => (
         <Marker
           key={chain.name}
           latitude={chain.latLon.latitude}

--- a/src/pages/signup.js
+++ b/src/pages/signup.js
@@ -29,15 +29,23 @@ class signup extends Component {
       email: "",
       loading: false,
       errors: {},
+      params: "",
     };
   }
 
   componentDidMount() {
-    getChains().then((chains) => {
-      this.setState({
-        chains,
+    getChains()
+      .then((chains) => {
+        this.setState({
+          chains,
+        });
+      })
+      .then(() => {
+        const urlParams = new URLSearchParams(window.location.search);
+        return this.setState({
+          params: urlParams.get("chain"),
+        });
       });
-    });
   }
 
   handleSubmit = (event) => {
@@ -73,18 +81,7 @@ class signup extends Component {
     const { errors } = this.state;
 
     let chainsMarkup = this.state.chains ? (
-      <Select
-        id="selectChain"
-        value={this.state.chains[0].name}
-        onChange={this.handleChange}
-        input={<Input />}
-      >
-        {this.state.chains.map((chain) => (
-          <MenuItem key={chain.name} value={chain.name}>
-            {chain.name}
-          </MenuItem>
-        ))}
-      </Select>
+      <h3>{this.state.params}</h3>
     ) : (
       <p>Loading...</p>
     );

--- a/src/util/theme.ts
+++ b/src/util/theme.ts
@@ -22,7 +22,7 @@ const theme = {
       textAlign: "center",
     },
     image: {
-      margin: "20px auto 20px auto",
+      margin: "50px auto auto auto",
     },
     pageTitle: {
       margin: "20px auto 20px auto",


### PR DESCRIPTION
Issue #14 

- refactored `map` code 
- removed sign up page from `navbar `
- added button to each chain pop up with routing to `signup` page
- chain's name gets transferred to `signup` page via query params 
- `signup` page renders the selected chain's name 
